### PR TITLE
Fix section error

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -23,8 +23,8 @@ class PagesController < ApplicationController
   	@page = Page.new(page_params)
     @page.subject = @subject
   	# Save the object
-  	if @page.save 
-  		flash[:notice] = "Page created successfully"
+  	if @page.save
+  		flash[:notice] = "Page created successfully."
   		redirect_to(pages_path(:subject_id => @subject.id))
   	else
   		render('new')
@@ -41,8 +41,8 @@ class PagesController < ApplicationController
   	# find objects using form parameters
   	@page = Page.find(params[:id])
   	if @page.update_attributes(page_params)
-  		flash[:notice] = "Page updated successfully"
-      redirect_to(page_path(@page,:subject_id => @subject.id))
+  		flash[:notice] = "Page updated successfully."
+      redirect_to(page_path(@page, :subject_id => @subject.id))
   	else
   		# If update and save fails
   		render('edit')
@@ -57,11 +57,11 @@ class PagesController < ApplicationController
   def destroy
   	@page = Page.find(params[:id])
   	@page.destroy
-  	flash[:notice] = "Page deleted successfully"
+  	flash[:notice] = "Page deleted successfully."
   	redirect_to(pages_path(:subject_id => @subject.id))
   end
 
-  private 
+  private
 
   def page_params
     params.require(:page).permit(:name, :position, :visible, :permalink)

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -26,7 +26,7 @@ class SectionsController < ApplicationController
   	@section = Section.new(section_params)
     @section.page =  @page
   	# Save the object
-  	if @section.save()
+  	if @section.save
   		flash[:notice] = "Section created successfully"
   		redirect_to(sections_path(:page_id => @page.id))
   	else 

--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -10,14 +10,14 @@ class AdminUser < ApplicationRecord
 	EMAIL_REGEX = /\A[a-z0-9._%+-]+@[a-z0-9]+\.[a-z]{2,4}\Z/i
 	FORBIDDEN_USERNAMES = ['littlebopeep','humptydumpty','marymary']
 
-	validates :first_name,  :presence => true,
+	validates :first_name,  :presence => false,
 							:length => { :maximum => 25 }
-	validates :last_name, 	:presence => true,
+	validates :last_name, 	:presence => false,
 							:length =>  {:maximum => 50 }
 	validates :username,  	:presence => true,
-							:length => {:within => 8..25},
+							:length => {:within => 3..25},
 							:uniqueness => true						
-	validates :email, 		:presence => true,
+	validates :email, 		:presence => false,
 							:length => {:maximum => 100 },
 							:format => {:with => EMAIL_REGEX},
 							:confirmation => true

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -1,6 +1,6 @@
 class Section < ApplicationRecord
 
-  acts_as_list :scope => :subject
+  acts_as_list :scope => :page
 
   belongs_to :page
   has_many :section_edits


### PR DESCRIPTION
Fix section error where the app would crash when creating a new section.
This happened because acts_as_list was scoped to subjects, when I should have scoped it to pages.
Now it's scoped to pages.